### PR TITLE
feat(scopes): introduce meta fields

### DIFF
--- a/addon/controllers/scopes/edit.js
+++ b/addon/controllers/scopes/edit.js
@@ -1,12 +1,27 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class ScopesEditController extends Controller {
+  @service emeisOptions;
+  @service intl;
+
+  get metaFields() {
+    return this.emeisOptions.metaFields.scope;
+  }
+
   @action
   updateModel(model, formElements) {
     model.name = formElements.name.value;
     model.description = formElements.description.value;
 
     return model;
+  }
+
+  @action
+  updateMetaField(field, model, optionOrEvent) {
+    const value = optionOrEvent.target?.value ?? optionOrEvent.value;
+    model.meta = { ...model.meta, [field.slug]: value };
+    model.notifyPropertyChange("meta");
   }
 }

--- a/addon/models/scope.js
+++ b/addon/models/scope.js
@@ -7,6 +7,7 @@ export default class ScopeModel extends LocalizedModel {
   @localizedAttr name;
   @localizedAttr description;
   @attr level;
+  @attr meta;
 
   @belongsTo("scope", { inverse: "children" }) parent;
   @hasMany("scope", { inverse: "parent" }) children;

--- a/addon/templates/scopes/edit.hbs
+++ b/addon/templates/scopes/edit.hbs
@@ -30,4 +30,31 @@
       {{scope.name}}
     </RelationshipSelect>
   </EditForm::Element>
+
+  {{#each this.metaFields as |field|}}
+    {{#if field.visible}}
+      <EditForm::Element @label={{get field.label this.intl.primaryLocale}}>
+        {{#if (eq field.type "choice")}}
+          <PowerSelect
+            @disabled={{field.readOnly}}
+            @options={{field.options}}
+            @selected={{find-by "value" (get @model.meta field.slug) field.options}}
+            @onChange={{fn this.updateMetaField field @model}}
+            @placeholder={{concat (get field.label this.intl.primaryLocale) "..."}}
+            as |option|
+          >
+            {{get option.label this.intl.primaryLocale}}
+          </PowerSelect>
+        {{else}}
+          <input
+            class="uk-input"
+            type="text"
+            value={{get @model.meta field.slug}}
+            disabled={{field.readOnly}}
+            {{on "input" (fn this.updateMetaField field @model)}}
+          >
+        {{/if}}
+      </EditForm::Element>
+    {{/if}}
+  {{/each}}
 </EditForm>

--- a/tests/dummy/app/services/emeis-options.js
+++ b/tests/dummy/app/services/emeis-options.js
@@ -8,4 +8,51 @@ export default class EmeisOptionsService extends Service {
   //   language: "optional",
   // };
   // navigationEntries = ["users", "scopes"];
+  metaFields = {
+    scope: [
+      {
+        slug: "meta-example",
+        label: {
+          en: "Example for custom choice field",
+          de: "Beispiel für benutzerdefiniertes Dropdown-Feld",
+        },
+        type: "choice", // initially supported: "text", "choice"
+        options: [
+          {
+            value: "option-1",
+            label: {
+              en: "Ham",
+              de: "Schinken",
+            },
+          },
+          {
+            value: "Option 2",
+            label: {
+              en: "Cheese",
+              de: "Käse",
+            },
+          },
+          {
+            value: "Option 3",
+            label: {
+              en: "Onion",
+              de: "Zwiebel",
+            },
+          },
+        ],
+        visible: true,
+        readOnly: false,
+      },
+      {
+        slug: "meta-example-2",
+        label: {
+          en: "Example for custom text field",
+          de: "Beispiel für benutzerdefiniertes Textfeld",
+        },
+        type: "text",
+        visible: true,
+        readOnly: false,
+      },
+    ],
+  };
 }


### PR DESCRIPTION
Meta fields can contain additional information on scopes and can be
passed by the `emeisOptions` service. The fields are customizable
in terms of readability and visibility.