### PR TITLE
feat: extract meta fields rendering into a component

### DIFF
--- a/addon/components/meta-fields.hbs
+++ b/addon/components/meta-fields.hbs
@@ -1,0 +1,27 @@
+{{#each @fields as |field|}}
+  {{#if field.visible}}
+    <EditForm::Element @label={{get field.label this.intl.primaryLocale}}>
+      {{#if (eq field.type "choice")}}
+        <PowerSelect
+          @disabled={{field.readOnly}}
+          @options={{field.options}}
+          @selected={{find-by "value" (get @model.meta field.slug) @field.options}}
+          @onChange={{fn this.updateMetaField field @model}}
+          @placeholder={{concat (get field.label this.intl.primaryLocale) "..."}}
+          as |option|
+        >
+          {{get option.label this.intl.primaryLocale}}
+        </PowerSelect>
+      {{/if}}
+      {{#if (eq field.type "text")}}
+        <input
+            class="uk-input"
+            type="text"
+            value={{get @model.meta field.slug}}
+            disabled={{field.readOnly}}
+            {{on "input" (fn this.updateMetaField field @model)}}
+        >
+      {{/if}}
+    </EditForm::Element>
+  {{/if}}
+{{/each}}

--- a/addon/components/meta-fields.js
+++ b/addon/components/meta-fields.js
@@ -1,0 +1,14 @@
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import Component from "@glimmer/component";
+
+export default class EditFormComponent extends Component {
+  @service intl;
+
+  @action
+  updateMetaField(field, model, optionOrEvent) {
+    const value = optionOrEvent.target?.value ?? optionOrEvent.value;
+    model.meta = { ...model.meta, [field.slug]: value };
+    model.notifyPropertyChange("meta");
+  }
+}

--- a/addon/controllers/scopes/edit/index.js
+++ b/addon/controllers/scopes/edit/index.js
@@ -7,7 +7,7 @@ export default class ScopesEditIndexController extends Controller {
   @service intl;
 
   get metaFields() {
-    return this.emeisOptions.metaFields.scope;
+    return this.emeisOptions.metaFields?.scope;
   }
 
   @action
@@ -16,12 +16,5 @@ export default class ScopesEditIndexController extends Controller {
     model.description = formElements.description.value;
 
     return model;
-  }
-
-  @action
-  updateMetaField(field, model, optionOrEvent) {
-    const value = optionOrEvent.target?.value ?? optionOrEvent.value;
-    model.meta = { ...model.meta, [field.slug]: value };
-    model.notifyPropertyChange("meta");
   }
 }

--- a/addon/controllers/users/edit/index.js
+++ b/addon/controllers/users/edit/index.js
@@ -8,6 +8,10 @@ export default class UsersEditIndexController extends Controller {
   @service intl;
   @service emeisOptions;
 
+  get metaFields() {
+    return this.emeisOptions.metaFields?.user;
+  }
+
   @action
   updateModel(model, formElements) {
     model.firstName = formElements.firstName.value;

--- a/addon/templates/scopes/edit/index.hbs
+++ b/addon/templates/scopes/edit/index.hbs
@@ -35,30 +35,8 @@
     </RelationshipSelect>
   </EditForm::Element>
 
-  {{#each this.metaFields as |field|}}
-    {{#if field.visible}}
-      <EditForm::Element @label={{get field.label this.intl.primaryLocale}}>
-        {{#if (eq field.type "choice")}}
-          <PowerSelect
-            @disabled={{field.readOnly}}
-            @options={{field.options}}
-            @selected={{find-by "value" (get @model.meta field.slug) field.options}}
-            @onChange={{fn this.updateMetaField field @model}}
-            @placeholder={{concat (get field.label this.intl.primaryLocale) "..."}}
-            as |option|
-          >
-            {{get option.label this.intl.primaryLocale}}
-          </PowerSelect>
-        {{else}}
-          <input
-            class="uk-input"
-            type="text"
-            value={{get @model.meta field.slug}}
-            disabled={{field.readOnly}}
-            {{on "input" (fn this.updateMetaField field @model)}}
-          >
-        {{/if}}
-      </EditForm::Element>
-    {{/if}}
-  {{/each}}
+  <MetaFields
+    @model={{@model}}
+    @fields={{this.metaFields}}
+  />
 </EditForm>

--- a/addon/templates/users/edit/index.hbs
+++ b/addon/templates/users/edit/index.hbs
@@ -125,6 +125,11 @@
     </EditForm::Element>
   {{/if}}
 
+  <MetaFields
+    @model={{@model}}
+    @fields={{this.metaFields}}
+  />
+
   <EditForm::Element @label={{t "emeis.users.headings.isActive"}}>
     <input
       class="uk-checkbox"

--- a/app/components/meta-fields.js
+++ b/app/components/meta-fields.js
@@ -1,0 +1,1 @@
+export { default } from "ember-emeis/components/meta-fields";

--- a/tests/dummy/app/services/emeis-options.js
+++ b/tests/dummy/app/services/emeis-options.js
@@ -9,6 +9,18 @@ export default class EmeisOptionsService extends Service {
   // };
   // navigationEntries = ["users", "scopes"];
   metaFields = {
+    user: [
+      {
+        slug: "user-meta-example",
+        label: {
+          en: "Example for custom text field",
+          de: "Beispiel für benutzerdefiniertes Textfeld",
+        },
+        type: "text",
+        visible: true,
+        readOnly: false,
+      },
+    ],
     scope: [
       {
         slug: "meta-example",

--- a/tests/integration/components/meta-fields-test.js
+++ b/tests/integration/components/meta-fields-test.js
@@ -1,0 +1,14 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Integration | Component | meta-fields", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders", async function (assert) {
+    await render(hbs`<MetaFields />`);
+
+    assert.dom(this.element).hasText("");
+  });
+});


### PR DESCRIPTION
Currently this will only allow metafields of type `text`