### PR TITLE
chore: drop support for node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sass": "1.38.2"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || >= 14"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
BREAKING CHANGE: drop support for node 10 as it has reached EOL.