### PR TITLE
fix(data-table): do not include page query param when searching

### DIFF
--- a/addon/components/data-table.hbs
+++ b/addon/components/data-table.hbs
@@ -67,11 +67,13 @@
                 {{t "emeis.pagination.previous"}}
               </button>
             </li>
-            <li class="uk-active">
+            {{#if this.numPages}}
+              <li class="uk-active">
               <span data-test-page>
                 {{this.page}} / {{this.numPages}}
               </span>
-            </li>
+              </li>
+            {{/if}}
             <li
               class={{unless this.nextPage "uk-disabled"}}
               data-test-next-page

--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -56,19 +56,25 @@ export default class DataTableComponent extends Component {
       typeof this.args.modelName === "string"
     );
 
-    const options = {
-      page: {
-        number: this.page,
-        size: this.emeisOptions.pageSize,
-      },
+    let options = {
       filter: { search: this.search, ...(this.args.filter || {}) },
       sort: this.args.sort,
       include: this.args.include || "",
     };
 
+    if (!this.search) {
+      options = {
+        ...options,
+        page: {
+          number: this.page,
+          size: this.emeisOptions.pageSize,
+        },
+      };
+    }
+
     const data = yield this.store.query(this.args.modelName, options);
 
-    this.numPages = data.meta.pagination.pages;
+    this.numPages = data.meta.pagination?.pages;
 
     return data;
   }


### PR DESCRIPTION
The search should take place over all entries and not only for the
ones on the current page.