### PR TITLE
chore: fix a couple of cli warnings /deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default class App extends Application {
   // ...
 
   this.engines = {
-    emberEmeis: {
+    "ember-emeis": {
       dependencies: {
         services: ["store", "intl", "notification", "router"],
       },
@@ -54,7 +54,7 @@ export default class App extends Application {
   // ...
 
   this.engines = {
-    emberEmeis: {
+    "ember-emeis": {
       dependencies: {
         services: ["store", "intl", "notification", "router", "emeis-options"],
       },

--- a/addon/components/edit-form.hbs
+++ b/addon/components/edit-form.hbs
@@ -19,8 +19,7 @@
       <UkButton
         @loading={{this.delete.isRunning}}
         @disabled={{this.delete.isRunning}}
-        @color="danger"
-        class="uk-margin-right"
+        class="uk-margin-right uk-button-danger"
         data-test-delete
         {{on "click" (perform this.delete)}}
       >

--- a/tests/acceptance/data-table-test.js
+++ b/tests/acceptance/data-table-test.js
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupIntl } from "ember-intl/test-support";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
 
@@ -15,6 +16,7 @@ import setupRequestAssertions from "./../helpers/assert-request";
 module("Acceptance | data-table", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
   setupRequestAssertions(hooks);
 
   test("search", async function (assert) {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -13,7 +13,7 @@ export default class App extends Application {
     super(...args);
 
     this.engines = {
-      emberEmeis: {
+      "ember-emeis": {
         dependencies: {
           services: [
             "store",

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -1,10 +1,12 @@
 import { render, click, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 module("Integration | Component | data-table", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test("fetch and display correct data", async function (assert) {
     assert.expect(11);

--- a/tests/integration/components/data-table/body-test.js
+++ b/tests/integration/components/data-table/body-test.js
@@ -1,10 +1,12 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 module("Integration | Component | data-table/body", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     this.set("models", [{ name: "Test 1" }, { name: "Test 2" }]);

--- a/tests/integration/components/edit-form-test.js
+++ b/tests/integration/components/edit-form-test.js
@@ -1,10 +1,13 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 module("Integration | Component | edit-form", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
+
   hooks.beforeEach(function () {
     const router = class {
       replaceWith() {}

--- a/tests/integration/helpers/indent-test.js
+++ b/tests/integration/helpers/indent-test.js
@@ -9,7 +9,7 @@ module("Integration | Helper | indent", function (hooks) {
   test("it renders", async function (assert) {
     this.set("inputValue", 3);
 
-    await render(hbs`{{indent inputValue}}`);
+    await render(hbs`{{indent this.inputValue}}`);
 
     assert.strictEqual(this.element.textContent, "\xa0".repeat(9));
   });

--- a/tests/unit/controllers/users/edit/acl-test.js
+++ b/tests/unit/controllers/users/edit/acl-test.js
@@ -1,10 +1,12 @@
 import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupIntl } from "ember-intl/test-support";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 import setupRequestAssertions from "./../../../../helpers/assert-request";
 module("Unit | Controller | users/edit/acl", function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
   setupMirage(hooks);
   setupRequestAssertions(hooks);
 


### PR DESCRIPTION
While testing there was a lot of noise in the console-output. This fixes most of them.

One crucial one is still open:
- [ ] [fix router (name) mapping for host/engine dependencies](https://ember-engines.com/docs/deprecations#-use-alias-for-inject-router-service-from-host-application)