### PR TITLE
fix(emeisOptions): include model in custom button callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export default class EmeisOptionsService extends Service {
   // show only a subset of the main navigation entries
   navigationEntries = ["users", "scopes"];
 
-  // On each model edit view (e.g. users) you can define a list of custom buttons. Each button needs a label and a callback function. Optionally you can highlight the button with the 'type' attribute.
+  // On each model edit view (e.g. users) you can define a list of custom buttons. Each button needs a label and a callback function. The callback function gets the current active model as first argument. Optionally you can highlight the button with the 'type' attribute.
   customButtons = {
     users: [
       {
@@ -98,7 +98,7 @@ export default class EmeisOptionsService extends Service {
       },
       {
         label: "A second Button",
-        callback: () => window.alert("test"),
+        callback: (model) => console.log(model),
       }
     ]
   };

--- a/addon/components/edit-form.hbs
+++ b/addon/components/edit-form.hbs
@@ -12,7 +12,7 @@
           @type="button"
           @label={{optional-translate button.label}}
           class="uk-margin-right {{if button.type (concat 'uk-button-' button.type) ''}}"
-          {{on "click" (fn this.customAction button)}}
+          {{on "click" (fn this.customAction button @model)}}
           data-test-custom-button
         />
       {{/each}}

--- a/addon/components/edit-form.js
+++ b/addon/components/edit-form.js
@@ -49,13 +49,13 @@ export default class EditFormComponent extends Component {
   }
 
   @action
-  customAction(button) {
+  customAction(button, model) {
     if (typeof button.callback !== "function") {
       this.notification.danger(
         this.intl.t("emeis.form.custom-button-action-error")
       );
     }
-    button.callback();
+    button.callback(model);
   }
 
   @task


### PR DESCRIPTION
It's not breaking the API, since we had no passed arguments to the callback function before, right? ;-)