### PR TITLE
fix: special icon and info for empty acl list

### DIFF
--- a/addon/components/data-table.hbs
+++ b/addon/components/data-table.hbs
@@ -51,7 +51,7 @@
   {{else}}
     {{yield
       (hash
-        body=(component "data-table/body" models=this.data.value)
+        body=(component "data-table/body" models=this.data.value emptyWarning=@emptyWarning emptyIcon=@emptyIcon emptyIconColor=@emptyIconColor)
         head=(component "data-table/head" sortedBy=this.sort update=this.updateSort)
         refresh=(perform this.fetchData)
       )

--- a/addon/components/data-table/body.hbs
+++ b/addon/components/data-table/body.hbs
@@ -11,12 +11,16 @@
       >
         <UkIcon
           @ratio="5"
-          @icon="search"
-          class="uk-margin-bottom"
+          @icon={{or @emptyIcon "search"}}
+          class={{if @emptyIconColor (concat 'uk-text-' @emptyIconColor) "uk-margin-bottom"}}
           data-test-loading
         />
         <span>
-          {{t "emeis.empty"}}
+          {{#if @emptyWarning}}
+            {{@emptyWarning}}
+          {{else}}
+            {{t "emeis.empty"}}
+          {{/if}}
         </span>
       </UkFlex>
     </td>

--- a/addon/templates/scopes/edit.hbs
+++ b/addon/templates/scopes/edit.hbs
@@ -73,7 +73,12 @@
             </tr>
           </tbody>
         {{else}}
-          <table.body as |body|>
+          <table.body
+            @emptyIcon="warning"
+            @emptyIconColor="warning"
+            @emptyWarning={{t "emeis.scopes.emptyAclList"}}
+            as |body|
+          >
             <body.row>
               {{#let body.model as |aclEntry|}}
                 <td data-test-acl-name={{aclEntry.id}}>

--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -196,7 +196,13 @@
               </tr>
             </tbody>
           {{else}}
-            <table.body as |body|>
+            <table.body
+              @emptyIcon="warning"
+              @emptyIconColor="warning"
+              @emptyWarning={{t "emeis.users.emptyAclList"}}
+              as |body|
+            >
+
               <body.row>
                 {{#let body.model as |aclEntry|}}
                   <td data-test-acl-role={{aclEntry.id}}>

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -6,7 +6,7 @@ emeis:
   general-error: "Ein Problem ist aufgetretten. Bitte versuchen Sie es erneut."
 
   scopes:
-    title: "Berechtigungsbereiche"
+    title: "Organisationen"
     headings:
       name: "Name"
       description: "Beschreibung"
@@ -16,7 +16,8 @@ emeis:
       edit-scope: "Berechtigungsbereich bearbeiten"
       acl:
         title: "Berechtigung"
-    aclHint: "Berechtigungen können erst hinzugefügt werden, sobald die Organisation gespeichert wurde."
+    emptyAclList: "Diese Organisation enthält keine Zugriffsrechte."
+    aclHint: "Zugriffsrechte können erst hinzugefügt werden, sobald die Organisation gespeichert wurde."
 
   users:
     title: "Benutzer"
@@ -32,7 +33,7 @@ emeis:
       city: "Stadt"
       zip: "PLZ"
       isActive: "Aktiv"
-    aclHint: "Berechtigungen können er hinzugefügt werden, wenn der neue Benutzer gespeichert wurde."
+    aclHint: "Zugriffsrechte können erst hinzugefügt werden, wenn der neue Benutzer gespeichert wurde."
 
     edit:
       edit-user: "Benutzer Bearbeiten"
@@ -76,21 +77,21 @@ emeis:
     custom-button-action-error: "Die konfigurierte Custom Button Action ist keine valide Funktion."
 
   acl-table:
-    title: "Berechtigung"
+    title: "Zugriffsrechte"
     headings:
       name: "Name"
       user: "Benutzername"
       scope: "Berechtigungsbereich"
       role: "Rolle"
       add-entry: "Eintrag hinzufügen"
-    new-user-hint: "Berechtigungen können erst hinzugefügt werden, sobald der neue Benutzer gespeichert wurde."
+    new-user-hint: "Zugriffsrechte können erst hinzugefügt werden, sobald der neue Benutzer gespeichert wurde."
 
   acl-wizzard:
-    add-entry: "Berechtigung hinzufügen"
-    duplicate: "Diese Kombination von Berechtigungen existiert bereits."
+    add-entry: "Zugriffsrechte hinzufügen"
+    duplicate: "Diese Kombination von Zugriffsrechten existiert bereits."
     scope:
-      select: "Klicken Sie hier um einen Berechtigungsbereich auszuwählen"
-      select-different: "Anderen Berechtigungsbereich auswählen"
+      select: "Klicken Sie hier um einen Organisation auszuwählen"
+      select-different: "Andere Organisation auswählen"
     role:
       select: "Klicken Sie hier um eine Rolle auszuwählen"
       select-different: "Andere Rolle auswählen"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -16,6 +16,7 @@ emeis:
       edit-scope: "Edit scope"
       acl:
         title: "ACL"
+    emptyAclList: "This scope includes no permissions yet."
     aclHint: "You can add ACLs once the new scope has been saved."
 
   users:
@@ -32,6 +33,7 @@ emeis:
       city: "City"
       zip: "ZIP"
       isActive: "Active"
+    emptyAclList: "This user has no permissions yet."
     aclHint: "You can add ACLs once the new user has been saved."
 
     edit:


### PR DESCRIPTION
Not sure about the default wording of the warning when a user has no active ACL or a scope has no ACL.

> "This scope includes no permissions yet."