### PR TITLE
fix!: rename meta attribute to metainfo (django-rf change)

### DIFF
--- a/addon/components/meta-fields.hbs
+++ b/addon/components/meta-fields.hbs
@@ -5,7 +5,7 @@
         <PowerSelect
           @disabled={{eval-meta field.readOnly @model}}
           @options={{field.options}}
-          @selected={{find-by "value" (get @model.meta field.slug) field.options}}
+          @selected={{find-by "value" (get @model.metainfo field.slug) field.options}}
           @onChange={{fn this.updateMetaField field @model}}
           @placeholder={{t field.label}}
           @allowClear={{true}}
@@ -20,7 +20,7 @@
           data-test-meta-field-text={{field.slug}}
           class="uk-input"
           type="text"
-          value={{get @model.meta field.slug}}
+          value={{get @model.metainfo field.slug}}
           disabled={{eval-meta field.readOnly @model}}
           {{on "input" (fn this.updateMetaField field @model)}}
         >

--- a/addon/components/meta-fields.js
+++ b/addon/components/meta-fields.js
@@ -8,7 +8,7 @@ export default class EditFormComponent extends Component {
   @action
   updateMetaField(field, model, optionOrEvent) {
     const value = optionOrEvent?.target?.value ?? optionOrEvent?.value;
-    model.meta = { ...model.meta, [field.slug]: value };
-    model.notifyPropertyChange("meta");
+    model.metainfo = { ...model.metainfo, [field.slug]: value };
+    model.notifyPropertyChange("metainfo");
   }
 }

--- a/addon/models/scope.js
+++ b/addon/models/scope.js
@@ -8,7 +8,7 @@ export default class ScopeModel extends LocalizedModel {
   @localizedAttr fullName;
   @localizedAttr description;
   @attr level;
-  @attr meta;
+  @attr metainfo;
 
   @belongsTo("scope", { inverse: "children", async: false }) parent;
   @hasMany("scope", { inverse: "parent", async: false }) children;

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -13,7 +13,7 @@ export default class UserModel extends LocalizedModel {
   @attr address;
   @localizedAttr city;
   @attr zip;
-  @attr meta;
+  @attr metainfo;
   @attr isActive;
 
   get fullName() {

--- a/tests/dummy/mirage/factories/scope.js
+++ b/tests/dummy/mirage/factories/scope.js
@@ -11,5 +11,5 @@ export default Factory.extend({
     ),
   description: () => localize(faker.lorem.paragraph()),
   level: () => 0,
-  meta: () => {},
+  metainfo: () => {},
 });

--- a/tests/dummy/mirage/factories/user.js
+++ b/tests/dummy/mirage/factories/user.js
@@ -14,6 +14,6 @@ export default Factory.extend({
   address: () => faker.address.streetAddress(),
   city: () => localize(faker.address.city()),
   zip: () => faker.datatype.number(),
-  meta: () => {},
+  metainfo: () => {},
   isActive: () => faker.datatype.boolean(),
 });

--- a/tests/integration/components/meta-fields-test.js
+++ b/tests/integration/components/meta-fields-test.js
@@ -78,7 +78,7 @@ module("Integration | Component | meta-fields", function (hooks) {
     this.emeisOptions = this.owner.lookup("service:emeisOptions");
 
     this.model = {
-      meta: {},
+      metainfo: {},
       notifyPropertyChange: () => {},
     };
   });
@@ -106,12 +106,12 @@ module("Integration | Component | meta-fields", function (hooks) {
     assert.dom(this.element).containsText(translations.scope.metaExample2);
 
     await selectChoose(".ember-power-select-trigger", "Ham");
-    assert.deepEqual(this.model.meta, {
+    assert.deepEqual(this.model.metainfo, {
       "meta-example": "option-1",
     });
 
     await fillIn("[data-test-meta-field-text]", "My value");
-    assert.deepEqual(this.model.meta, {
+    assert.deepEqual(this.model.metainfo, {
       "meta-example": "option-1",
       "meta-example-2": "My value",
     });


### PR DESCRIPTION
Since django rest framework made this key a reserved attribute, we have to rename it for our usage.
More info [see here](https://github.com/projectcaluma/emeis/releases/tag/v1.0.0)

This change requires the emeis backend version >= 1.0.0

!BREAKING CHANGE