### PR TITLE
feat(emeis-options): add setting to force the locale of models

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ export default class EmeisOptionsService extends Service {
   // number of items in list views
   pageSize = 10;
 
+  // force the locale of models to a specific value (i.e. to make it "untranslated")
+  forceLocale = {
+    scope: "en",
+  };
+
   // hide "username" field
   emailAsUsername = false;
 

--- a/addon/models/localized.js
+++ b/addon/models/localized.js
@@ -3,6 +3,7 @@ import { inject as service } from "@ember/service";
 
 export default class LocalizedModel extends Model {
   @service intl;
+  @service emeisOptions;
 
   getUnlocalizedField(field) {
     return this[`_${field}`];
@@ -10,7 +11,7 @@ export default class LocalizedModel extends Model {
 
   getFieldLocale() {
     return (
-      this.localizedFieldLocale ||
+      this.emeisOptions.forceLocale?.[this.constructor.modelName] ||
       this.intl.localizedFieldLocale ||
       this.intl.primaryLocale
     );

--- a/addon/templates/scopes/edit.hbs
+++ b/addon/templates/scopes/edit.hbs
@@ -6,12 +6,12 @@
         @updateModel={{this.updateModel}}
         @listViewRouteName="scopes.index"
       >
-        <EditForm::Element @label={{t "emeis.scopes.headings.name"}}>
+        <EditForm::Element @label={{t "emeis.scopes.headings.fullName"}}>
           <input
             class="uk-input"
             type="text"
             name="name"
-            placeholder="{{t "emeis.scopes.headings.name"}}..."
+            placeholder="{{t "emeis.scopes.headings.fullName"}}..."
             required
             value={{@model.name}}
           />

--- a/tests/dummy/app/services/emeis-options.js
+++ b/tests/dummy/app/services/emeis-options.js
@@ -3,6 +3,9 @@ import Service from "@ember/service";
 export default class EmeisOptionsService extends Service {
   emailAsUsername = false;
   pageSize = 10;
+  // forceLocale = {
+  //   scope: "en",
+  // };
   // additionalUserFields = {
   //   phone: "optional",
   //   language: "optional",


### PR DESCRIPTION
This makes the already existing override for field locales configurable
via the emeis-options service. The existing override on model level has
been removed, because it's not accessible when ember-emeis is used as an
engine.

The override is useful for cases when translations for specific models
are not required / wanted.