### PR TITLE
fix(translations): consistent warning msg for user deletion

### DIFF
--- a/addon/controllers/users/index.js
+++ b/addon/controllers/users/index.js
@@ -24,7 +24,7 @@ export default class UsersIndexController extends PaginationController {
   }
 
   @task
-  @confirmTask({ message: "emeis.form.confirmUserDelete" })
+  @confirmTask({ message: "emeis.form.confirmEntryDelete" })
   @handleTaskErrors({ errorMessage: "emeis.form.delete-error" })
   *delete(model) {
     yield model.destroyRecord();

--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -8,7 +8,6 @@
       <EditForm
         @model={{@model}}
         @updateModel={{this.updateModel}}
-        @noDelete={{true}}
         @listViewRouteName="users.index"
       >
         {{#unless this.emailAsUsername}}

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -75,7 +75,6 @@ emeis:
     cancel: "Abbrechen"
     confirmText: "Sind Sie sich sicher, dass Sie diese Aktion fortfahren wollen?"
     confirmEntryDelete: "Sind Sie sich sicher, dass Sie diesen Eintrag löschen wollen?"
-    confirmUserDelete: "Sind Sie sich sicher, dass Sie diesen Benutzer löschen wollen?"
     save-success: "Erfolgreich gespeichert."
     delete-success: "Erfolgreich gelöscht."
     save-error: "Während dem Speichern ist ein Fehler aufgetretten. Bitte versuchen Sie es erneut."

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -75,7 +75,6 @@ emeis:
     cancel: "Cancel"
     confirmText: "Are you sure you want to proceed with this action?"
     confirmEntryDelete: "Are you sure you want to delete this entry?"
-    confirmUserDelete: "Are you sure you want to delete this user?"
     save-success: "Saved successfully"
     delete-success: "Deleted successfully"
     save-error: "A problem occurred while saving. Please try again."


### PR DESCRIPTION
Because of the generic way `EditForm` is implemented, we currently show
a generic warning message when a user is deleted from the detail view.
This uses the same warning when a user is deleted from the list view
(for consistency).