### PR TITLE
fix: adapt table hover style

### DIFF
--- a/addon/components/data-table.hbs
+++ b/addon/components/data-table.hbs
@@ -32,7 +32,7 @@
 </div>
 
 <table
-  class="uk-table uk-table-striped"
+  class="uk-table uk-table-striped uk-table-hover"
   ...attributes
 >
 


### PR DESCRIPTION
In the host app we use the yellow hover style as well.