### PR TITLE
style: improve inactive model stylez

### DIFF
--- a/addon/components/tree-node.hbs
+++ b/addon/components/tree-node.hbs
@@ -6,7 +6,7 @@
       {{/unless}}
     </UkButton>
   {{/if}}
-  <LinkTo @route={{@itemRoute}} @model={{@item}} class="uk-link-text {{unless @item.isActive "text-line-through"}}" data-test-node-id={{@item.id}}>
+  <LinkTo @route={{@itemRoute}} @model={{@item}} class="uk-link-text {{unless @item.isActive "text-line-through uk-text-muted"}}" data-test-node-id={{@item.id}}>
     {{@item.name}}{{#if @item.children}} ({{@item.children.length}}){{/if}}
   </LinkTo>
   {{#if this.expanded}}

--- a/addon/templates/scopes/edit.hbs
+++ b/addon/templates/scopes/edit.hbs
@@ -1,6 +1,10 @@
 <div uk-grid class="uk-grid-divider uk-grid-divider-fix">
     <div class="uk-width-1-2@xl">
-      <h3>{{t "emeis.scopes.edit.edit-scope"}}</h3>
+      <h3>{{t "emeis.scopes.edit.edit-scope"}}
+        {{#unless @model.isActive}}
+          <span class="uk-badge uk-background-secondary">{{t "emeis.inactive"}}</span>
+        {{/unless}}
+      </h3>
       <EditForm
         @model={{@model}}
         @updateModel={{this.updateModel}}

--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -4,7 +4,11 @@
 </LinkTo>
 <div uk-grid class="uk-grid-divider">
     <div class="uk-width-1-2@l">
-      <h3>{{t "emeis.users.edit.edit-user"}}</h3>
+      <h3>{{t "emeis.users.edit.edit-user"}}
+        {{#unless @model.isActive}}
+          <span class="uk-badge uk-background-secondary">{{t "emeis.inactive"}}</span>
+        {{/unless}}
+      </h3>
       <EditForm
         @model={{@model}}
         @updateModel={{this.updateModel}}

--- a/addon/templates/users/index.hbs
+++ b/addon/templates/users/index.hbs
@@ -49,14 +49,14 @@
               {{user.username}}
             </LinkTo>
           </td>
-          <td>{{user.lastName}}</td>
-          <td>{{user.firstName}}</td>
+          <td class="uk-link-text {{unless user.isActive "text-line-through"}}">{{user.lastName}}</td>
+          <td class="uk-link-text {{unless user.isActive "text-line-through"}}">{{user.firstName}}</td>
         {{/if}}
 
-        <td data-test-user-email={{user.id}}>
+        <td class="uk-link-text {{unless user.isActive "text-line-through"}}" data-test-user-email={{user.id}}>
           {{user.email}}
         </td>
-        <td>
+        <td class="uk-link-text {{unless user.isActive "text-line-through"}}">
           <ul class="uk-list uk-list-divider">
             {{#each user.acls as |acl|}}
               <li>
@@ -74,7 +74,7 @@
           </ul>
         </td>
         {{!-- SCOPES --}}
-        <td>
+        <td class="uk-link-text {{unless user.isActive "text-line-through"}}">
           <ul class="uk-list uk-list-divider">
             {{#each user.acls as |acl|}}
               <li>

--- a/addon/templates/users/index.hbs
+++ b/addon/templates/users/index.hbs
@@ -42,7 +42,7 @@
               {{user.lastName}}
             </LinkTo>
           </td>
-          <td>{{user.firstName}}</td>
+          <td class="uk-link-text {{unless user.isActive "text-line-through"}}">{{user.firstName}}</td>
         {{else}}
           <td data-test-user-username={{user.id}}>
             <LinkTo @route="users.edit" @model={{user}} class="uk-link-text {{unless user.isActive "text-line-through"}}">

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -3,6 +3,7 @@ emeis:
   not-found: "Diese Seite konnte nicht gefunden werden."
   empty: "Keine Einträge gefunden..."
   loading: "Laden..."
+  inactive: "Inaktiv"
   general-error: "Ein Problem ist aufgetretten. Bitte versuchen Sie es erneut."
   actions: "Aktionen"
   export: "Export"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -3,6 +3,7 @@ emeis:
   not-found: "This page could not be found."
   empty: "No entries found..."
   loading: "Loading..."
+  inactive: "Inactive"
   general-error: "A problem occured. Please try again."
   actions: "Actions"
   export: "Export"


### PR DESCRIPTION
- adds an "inactive" badge to deactivated models (user/scope)
- stretch line-through styling across the all `<td>` elements of a deactivated user instead off only the first one (username)