### PR TITLE
fix: handle case where engine is mounted under different name

### DIFF
--- a/addon/controllers/scopes.js
+++ b/addon/controllers/scopes.js
@@ -5,7 +5,7 @@ export default class ScopesController extends Controller {
   @service router;
 
   get activeScope() {
-    if (!this.router.currentRouteName.includes("ember-emeis.scopes.edit")) {
+    if (!this.router.currentRouteName.includes("scopes.edit")) {
       return null;
     }
     return this.router.currentRoute.attributes;


### PR DESCRIPTION
We only assert the route segment that we're sure of, making collisions
slightly more likely but still unlikely enough (hopefully).