### PR TITLE
fix: tree search expansion

### DIFF
--- a/addon/components/tree.js
+++ b/addon/components/tree.js
@@ -31,7 +31,7 @@ export default class TreeComponent extends Component {
         // we need the children in the list of expanded items, so we can expand the "searched" items.
         item.children.forEach((child) => expanded.push(child));
       });
-      return expanded.map((item) => item.id);
+      return expanded;
     }
     const rootNodes = this.args.items?.filter((i) => i.level === 0);
     return this.args.activeItem?.findParents
@@ -72,6 +72,6 @@ export default class TreeComponent extends Component {
 
   @action
   filterItemList(item) {
-    return this.expandedItems.includes(item);
+    return this.expandedItems.map((item) => item.id).includes(item);
   }
 }

--- a/addon/components/tree.js
+++ b/addon/components/tree.js
@@ -72,6 +72,6 @@ export default class TreeComponent extends Component {
 
   @action
   filterItemList(item) {
-    return this.expandedItems.map((item) => item.id).includes(item);
+    return this.expandedItems.find(({ id }) => id === item);
   }
 }

--- a/addon/controllers/scopes.js
+++ b/addon/controllers/scopes.js
@@ -3,6 +3,7 @@ import { inject as service } from "@ember/service";
 
 export default class ScopesController extends Controller {
   @service router;
+  @service store;
 
   get activeScope() {
     if (!this.router.currentRouteName.includes("scopes.edit")) {
@@ -12,6 +13,6 @@ export default class ScopesController extends Controller {
   }
 
   get rootScopes() {
-    return this.model?.filter((scope) => !scope.parent);
+    return this.store.peekAll("scope").filter((scope) => !scope.parent);
   }
 }

--- a/addon/routes/scopes/new.js
+++ b/addon/routes/scopes/new.js
@@ -4,6 +4,6 @@ export default class ScopesNewRoute extends CreateRoute {
   detailView = "scopes.edit";
 
   model() {
-    return this.store.createRecord("scope");
+    return this.store.createRecord("scope", { isActive: true });
   }
 }


### PR DESCRIPTION
In case of only one root element in the scopes list, searching for another entry didn't reveal child elements correctly.

This MR contains two fixes:
 - fix the search for the scopes tree
 - trigger a refresh of the scopes index (tree) when storing new scopes