### PR TITLE
fix(editForm): relax phone regex

### DIFF
--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -73,7 +73,7 @@
               name="phone"
               placeholder="{{t "emeis.users.headings.phone-placeholder"}}..."
               required={{includes "phone" this.requiredFields}}
-              pattern="^[0-9()\-\s]+$"
+              pattern="^[0-9()\+\-\s]+$"
               value={{@model.phone}}
             />
 


### PR DESCRIPTION
Previously phone numbers starting with `+` would get rejected. But the country code format is quite common.