### PR TITLE
fix: always sort scopes client-side

### DIFF
--- a/addon/templates/scopes/edit.hbs
+++ b/addon/templates/scopes/edit.hbs
@@ -33,7 +33,7 @@
 
         <EditForm::Element @label={{t "emeis.scopes.headings.parent"}} @optional={{true}}>
           <RelationshipSelect
-            @model={{this.allScopes}}
+            @model={{sort-by "fullName" this.allScopes}}
             @selected={{@model.parent}}
             @placeholder="{{t "emeis.scopes.headings.parent"}}..."
             @onChange={{this.setParent}} as |scope|


### PR DESCRIPTION
This is important when the ember store already contains data and we can't rely on the sort in the API response.

Based on #584 