### PR TITLE
chore(deps): upgrade ember-uikit to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-set-helper": "^2.0.1",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "ember-uikit": "^7.0.3",
+    "ember-uikit": "^8.0.0",
     "file-saver": "^2.0.5",
     "tracked-toolbox": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7262,7 +7262,7 @@ ember-engines@0.9.0:
     ember-cli-version-checker "^5.1.2"
     lodash "^4.17.11"
 
-ember-focus-trap@^1.0.1:
+ember-focus-trap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz#813ee3684b95f31a9534ef02f47da2bb7f5f13e9"
   integrity sha512-/8Cx9KI7uqoMaNN4Iyxc24P2JIvAcCL3cI1tYdZRHTwTd1sG6esEZWOnpxZOSE7m4xHww8HVUSiXzgyqD8YIhA==
@@ -7636,10 +7636,10 @@ ember-try@3.0.0-beta.1:
     rimraf "^3.0.2"
     walk-sync "^2.2.0"
 
-ember-uikit@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/ember-uikit/-/ember-uikit-7.0.3.tgz#33344a612258b0df833a758567b8f4edcfb05277"
-  integrity sha512-JKCOiP1paiJLMYK3fPlTDCCSCt4+6VLGchs1QL788S0hgkMJ2bCnA7JPMJ/Cb8Syzv3Lwk3b5XsLCF3NNmZ7MA==
+ember-uikit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ember-uikit/-/ember-uikit-8.0.0.tgz#1ab8d270312f2fc3683f6c7dd2fa0a234e79dfd1"
+  integrity sha512-+LhqFE7UK0/TRrgnip7oZYljD3r9lO1IIvUUZGq4B8cmleWBkyW7RHPLEaqgLJQbPzBzS7EhS0Oypkfg3RDg1Q==
   dependencies:
     "@ember/string" "^3.0.1"
     "@embroider/util" "^1.10.0"
@@ -7652,7 +7652,7 @@ ember-uikit@^7.0.3:
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.2.0"
     ember-composable-helpers "^5.0.0"
-    ember-focus-trap "^1.0.1"
+    ember-focus-trap "^1.0.2"
     ember-modifier "^4.1.0"
     ember-toggle "^9.0.3"
     ember-truth-helpers "^3.1.1"


### PR DESCRIPTION
`ember-uikit` drops ember `v3` support with this version!

We should merge this after  #625 is ready.