### PR TITLE
refactor(ember-set-helper): replace deprecated ember-simple-set-helper

### DIFF
--- a/addon/components/edit-form.hbs
+++ b/addon/components/edit-form.hbs
@@ -1,6 +1,6 @@
 <form
   class="uk-form-stacked"
-  {{did-insert (set this.form)}}
+  {{did-insert (set this "form")}}
   {{on "submit" (perform this.save)}}
 >
   {{yield}}

--- a/addon/components/tree.hbs
+++ b/addon/components/tree.hbs
@@ -7,7 +7,7 @@
           type="reset"
           class="uk-form-icon uk-form-icon-flip"
           uk-icon="close"
-          {{on "click" (set this.filterValue null)}}
+          {{on "click" (set this "filterValue" null)}}
           data-test-search-reset
         />
       {{/if}}

--- a/addon/templates/permissions/edit.hbs
+++ b/addon/templates/permissions/edit.hbs
@@ -49,7 +49,7 @@
       @modelName="role"
       @selected={{@model.roles}}
       @placeholder="{{t 'emeis.permissions.headings.roles'}}..."
-      @onChange={{set @model.roles}}
+      @onChange={{set @model "roles"}}
       @multiple="true"
       required
       as |role|

--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -182,7 +182,10 @@
   <div class="uk-width-1-2@l">
     {{#if this.showAclWizzard}}
       <span class="uk-flex uk-flex-left">
-        <UkButton data-test-acl-back @onClick={{set this.showAclWizzard false}}>
+        <UkButton
+          data-test-acl-back
+          @onClick={{set this "showAclWizzard" false}}
+        >
           <UkIcon @icon="arrow-left" @ratio="1.5" />
           {{t "emeis.form.back"}}
         </UkButton>
@@ -215,7 +218,7 @@
               <UkButton
                 data-test-add-acl
                 @color="primary"
-                @onClick={{set this.showAclWizzard true}}
+                @onClick={{set this "showAclWizzard" true}}
               >
                 {{t "emeis.acl-table.headings.add-entry"}}
               </UkButton>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-modifier": "^3.2.7",
     "ember-power-select": "^6.0.1",
     "ember-resources": "^5.6.4",
-    "ember-simple-set-helper": "^0.1.2",
+    "ember-set-helper": "^2.0.1",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
     "ember-uikit": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-set-helper": "^2.0.1",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
-    "ember-uikit": "^7.0.2",
+    "ember-uikit": "^7.0.3",
     "file-saver": "^2.0.5",
     "tracked-toolbox": "^2.0.0"
   },
@@ -88,7 +88,7 @@
     "ember-export-application-global": "2.0.1",
     "ember-load-initializers": "2.1.2",
     "ember-maybe-import-regenerator": "1.0.0",
-    "ember-qunit": "6.0.0",
+    "ember-qunit": "6.2.0",
     "ember-resolver": "8.0.3",
     "ember-source": "3.28.9",
     "ember-source-channel-url": "3.0.0",

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -6,9 +6,9 @@ import {
   fillIn,
   waitUntil,
   settled,
+  waitFor,
 } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { timeout } from "ember-concurrency";
 import { setupIntl } from "ember-intl/test-support";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
@@ -101,7 +101,7 @@ module("Acceptance | users", function (hooks) {
       "[data-test-filters-radio-buttons='active'] [data-test-filters-radio-buttons-button='off']"
     );
 
-    await timeout(100);
+    await waitFor("[data-test-user-username]");
 
     assert.dom("[data-test-user-username]").exists({
       count: users.filter((user) => user.isActive === false).length,
@@ -339,6 +339,7 @@ module("Acceptance | users", function (hooks) {
 
     await click("[data-test-add-acl]");
 
+    await waitFor("button[data-test-select-role]");
     await click("button[data-test-select-role]");
     // For some reason the await click is not actually waiting for the fetch task to finish.
     // Probably some runloop issue.

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -234,7 +234,7 @@ module("Integration | Component | data-table", function (hooks) {
       <DataTable
         @modelName="role"
         @search={{this.search}}
-        @updateSearch={{set this.search}}
+        @updateSearch={{set this "search"}}
         as |table|>
           <table.body as |body|>
             <body.row>

--- a/tests/integration/components/relationship-select-test.js
+++ b/tests/integration/components/relationship-select-test.js
@@ -26,7 +26,7 @@ module("Integration | Component | relationship-select", function (hooks) {
     await render(hbs`
       <RelationshipSelect
         @modelName={{this.modelName}}
-        @onChange={{set this.selected}}
+        @onChange={{set this "selected"}}
         @selected={{this.selected}}
         @placeholder="test"
         as |model|
@@ -61,7 +61,7 @@ module("Integration | Component | relationship-select", function (hooks) {
     await render(hbs`
       <RelationshipSelect
         @modelName={{this.modelName}}
-        @onChange={{set this.selected}}
+        @onChange={{set this "selected"}}
         @selected={{this.selected}}
         as |model|
       >
@@ -86,7 +86,7 @@ module("Integration | Component | relationship-select", function (hooks) {
     await render(hbs`
       <RelationshipSelect
         @modelName={{this.modelName}}
-        @onChange={{set this.selected}}
+        @onChange={{set this "selected"}}
         @selected={{this.selected}}
         @placeholder="test"
         @multiple="true"

--- a/tests/unit/decorators/confirm-task-test.js
+++ b/tests/unit/decorators/confirm-task-test.js
@@ -1,4 +1,4 @@
-import { click, waitFor } from "@ember/test-helpers";
+import { click, findAll, waitFor, waitUntil } from "@ember/test-helpers";
 import { task } from "ember-concurrency";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
@@ -42,11 +42,21 @@ module("Unit | decorators | confirm-task", function (hooks) {
 
   test("it does not trigger the action on cancel", async function (assert) {
     assert.expect(1);
+
     const instance = new this.TestStub();
     instance.deleteSomething.perform();
 
-    await waitFor(".uk-modal.uk-open");
+    await waitFor(".uk-modal-close");
     await click(".uk-modal-close");
+    // This fixes flaky test behavior, since UIKit needs a little more time to close the
+    // modal and handle it's state. Sadly this can not be awaited via the settled helper
+    // nor other ember built-ins.
+    await waitUntil(
+      function () {
+        return findAll(".uk-modal-close").length === 0;
+      },
+      { timeout: 2000 }
+    );
 
     assert.verifySteps([]);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5813,7 +5813,7 @@ ember-auto-import@^1.5.3:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-auto-import@^2.3.0, ember-auto-import@^2.4.2, ember-auto-import@^2.5.0, ember-auto-import@^2.6.0, ember-auto-import@^2.6.3:
+ember-auto-import@^2.3.0, ember-auto-import@^2.5.0, ember-auto-import@^2.6.0, ember-auto-import@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.6.3.tgz#f18d1b93dd10b08ba5496518436f9d56dd4e000a"
   integrity sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==
@@ -6558,20 +6558,20 @@ ember-power-select@^6.0.1:
     ember-text-measurer "^0.6.0"
     ember-truth-helpers "^3.1.0"
 
-ember-qunit@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-6.0.0.tgz#cea4766c297a25d58a3e886ccd4eb726167ea47c"
-  integrity sha512-idNWh9Ap2HN9e3Xozh5Jrciu5tDhn0okM/bgwDjdks3dwuMhEox45iiRTx469FWQ9+ixjZ40AsXsRTDkfCmvmw==
+ember-qunit@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-6.2.0.tgz#4d492951035d1df5c7802c4ae6cf299c8f41d75b"
+  integrity sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==
   dependencies:
     broccoli-funnel "^3.0.8"
     broccoli-merge-trees "^3.0.2"
     common-tags "^1.8.0"
-    ember-auto-import "^2.4.2"
-    ember-cli-babel "^7.26.6"
+    ember-auto-import "^2.6.0"
+    ember-cli-babel "^7.26.11"
     ember-cli-test-loader "^3.0.0"
     resolve-package-path "^4.0.3"
     silent-error "^1.1.1"
-    validate-peer-dependencies "^2.1.0"
+    validate-peer-dependencies "^2.2.0"
 
 ember-resolver@8.0.3:
   version "8.0.3"
@@ -15037,7 +15037,7 @@ validate-peer-dependencies@^1.1.0:
     resolve-package-path "^3.1.0"
     semver "^7.3.2"
 
-validate-peer-dependencies@^2.1.0:
+validate-peer-dependencies@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz#47b8ff008f66a66fc5d8699123844522c1d874f4"
   integrity sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5896,7 +5896,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -5948,7 +5948,7 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==
 
-ember-cli-htmlbars@^4.2.2, ember-cli-htmlbars@^4.3.1:
+ember-cli-htmlbars@^4.3.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz#d299e4f7eba6f30dc723ee086906cc550beb252e"
   integrity sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==
@@ -6608,13 +6608,12 @@ ember-router-generator@^2.0.0:
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
 
-ember-simple-set-helper@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-simple-set-helper/-/ember-simple-set-helper-0.1.2.tgz#f0aad11f35df5f0396561ee4552c1790d8ef0930"
-  integrity sha512-Dx66Ki7tqd3R0MpAmE1j1pTI/K5OAcW4XYpz0T23x8KVUWbaZE9zGGUPlxsczf/44ML3kyIvS7rzQ+6DHS7dkw==
+ember-set-helper@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-set-helper/-/ember-set-helper-2.0.1.tgz#e39417531e25089b45ccb905b8c00eda7b3fbbde"
+  integrity sha512-6IIimVGOdehZcncH1ilCY4p7hWBtZqWYMc1Xodr1ATOCuIk6ZO1yztKcUQhlmwl7fE82gL4wHD01T6XP5W59Ng==
   dependencies:
-    ember-cli-babel "^7.17.2"
-    ember-cli-htmlbars "^4.2.2"
+    ember-cli-babel "^7.18.0"
 
 ember-source-channel-url@3.0.0, ember-source-channel-url@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The old [ember-simple-set-helper](https://github.com/pzuraq/ember-simple-set-helper) is outdated and should get replaced by [ember-set-helper](https://github.com/pzuraq/ember-set-helper).