### PR TITLE
chore: revert pinning of node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CI: true
-  NODE_VERSION: 18.18.1
+  NODE_VERSION: 18
 
 jobs:
   lint:


### PR DESCRIPTION
the earlier change might have been enough to update the cache?