### PR TITLE
fix(user/edit): escape parenthesis in input pattern

### DIFF
--- a/addon/templates/users/edit.hbs
+++ b/addon/templates/users/edit.hbs
@@ -85,7 +85,7 @@
             name="phone"
             placeholder="{{t 'emeis.users.headings.phone-placeholder'}}"
             required={{includes "phone" this.requiredFields}}
-            pattern="^[0-9()\+\-\s]+$"
+            pattern="^[0-9\(\)\+\-\s]+$"
             value={{@model.phone}}
           />
 


### PR DESCRIPTION
The parenthesis needs to be escaped. The pattern itself is quite contestable as well..