### PR TITLE
fix: upgrade ember and drop node < v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ The frontend for the [emeis](https://github.com/projectcaluma/emeis) user manage
 
 ## Compatibility
 
-- Ember.js v5.8 or above
-- Ember CLI v5.8 or above
+- Ember.js v4.12 or above
 - Node.js v20 or above
 
 ## Installation


### PR DESCRIPTION
This commit should trigger a major release. The actual upgrades happended in 5515bc7

BREAKING CHANGE: drop support for node < 20 and ember < v4.12