### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CI: true
   NODE_VERSION: 22


### PR DESCRIPTION
Potential fix for [https://github.com/projectcaluma/ember-emeis/security/code-scanning/3](https://github.com/projectcaluma/ember-emeis/security/code-scanning/3)

In general, the fix is to explicitly set `permissions` for the workflow or for each job to ensure the `GITHUB_TOKEN` has only the minimal required privileges. Since these jobs only need to read the repository contents (for `actions/checkout` and to run code), we can set `contents: read`. Doing this at the workflow root is simplest and applies to all jobs that lack their own `permissions` block, matching the CodeQL suggestion and preserving existing behavior.

The best change here is to add a single `permissions:` block at the top level of `.github/workflows/test.yml`, just below the `on:` section (or just after it) so it clearly applies to all jobs. We’ll set:

```yaml
permissions:
  contents: read
```

No job-specific modifications or additional imports are needed. Functionality remains unchanged, but the `GITHUB_TOKEN` will now be restricted to read-only repository contents for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
