### PR TITLE
fix(acl-wizzard): track sort property

### DIFF
--- a/addon/components/acl-wizzard.js
+++ b/addon/components/acl-wizzard.js
@@ -11,6 +11,7 @@ export default class AclWizzardComponent extends Component {
   @tracked user;
   @tracked role;
   @tracked scope;
+  @tracked sort;
 
   fields = {
     user: ["username", "fullName", "email"],


### PR DESCRIPTION
We need to use `@tracked` to properly update descendants.